### PR TITLE
Remove system time dependencies from tests

### DIFF
--- a/src/AlarmClock.h
+++ b/src/AlarmClock.h
@@ -9,7 +9,6 @@
 #include <thread>
 #include <atomic>
 #include <future>
-#include <iostream>
 #include "StopWatch.h"
 
 
@@ -18,14 +17,6 @@ public:
    typedef std::chrono::microseconds microseconds;
    typedef std::chrono::milliseconds milliseconds;
    typedef std::chrono::seconds seconds;
-  
-   static AlarmClock AlarmClockCreator(unsigned int sleepDuration) {
-      AlarmClock clock(sleepDuration);
-      clock.mExited = std::move(std::async(std::launch::async,
-                         &AlarmClock::AlarmClockThread,
-                         &clock));
-      return std::move(clock);
-   }  
 
    AlarmClock(unsigned int sleepDuration) : mExpired(false),
       kSleepTime(sleepDuration),

--- a/src/AlarmClock.h
+++ b/src/AlarmClock.h
@@ -9,6 +9,7 @@
 #include <thread>
 #include <atomic>
 #include <future>
+#include <iostream>
 #include "StopWatch.h"
 
 
@@ -25,6 +26,7 @@ public:
       mExited(std::async(std::launch::async,
                          &AlarmClock::AlarmClockThread,
                          this)) {
+         std::cout << "AC: Hello Craig" << std::endl;
    }
    
    virtual ~AlarmClock() {
@@ -66,24 +68,24 @@ protected:
       return Duration(kSleepTime) <= milliseconds(kSmallestIntervalInMS);
    }
 
-   void SleepForFullAmount() {
+   virtual void SleepForFullAmount() {
       Sleep(kSleepTime);
       mExpired.store(true);
    }
 
-   void Sleep(unsigned int sleepTime) {
+   virtual void Sleep(unsigned int sleepTime) {
       std::this_thread::sleep_for(Duration(sleepTime)); 
    }
 
-   void Sleep(microseconds t) {
+   virtual void Sleep(microseconds t) {
       std::this_thread::sleep_for(t);
    }
 
-   void Sleep(milliseconds t) {
+   virtual void Sleep(milliseconds t) {
       std::this_thread::sleep_for(t); 
    }
    
-   void Sleep(seconds t) {
+   virtual void Sleep(seconds t) {
       std::this_thread::sleep_for(t); 
    }
 
@@ -102,13 +104,14 @@ protected:
              (kSleepTimeMs/kSmallestIntervalInMS);
    }
   
-   void SleepForRemainder(const unsigned int& currentSleptFor) {
+   virtual void SleepForRemainder(const unsigned int& currentSleptFor) {
       if (currentSleptFor < kSleepTimeUs) {
          Sleep(microseconds(kSleepTimeUs - currentSleptFor));
       }
    } 
 
-   void SleepInIntervals() {
+   virtual void SleepInIntervals() {
+      std::cout << "AC: Sleep in intervals" << std::endl;
       StopWatch timer;
       size_t numberOfSleeps = GetNumberOfSleepIntervals();
       while (KeepRunning() && numberOfSleeps > 0) {

--- a/src/AlarmClock.h
+++ b/src/AlarmClock.h
@@ -54,7 +54,7 @@ public:
 protected:
 
    void AlarmClockThread() {
-      SleepTimeIsBelow500ms() ? SleepForFullAmount() : SleepInIntervals();
+      SleepTimeIsBelow500ms() ? AlarmClock::SleepForFullAmount() : AlarmClock::SleepInIntervals();
    }
   
    void StopBackgroundThread() {
@@ -109,7 +109,6 @@ protected:
    } 
 
    void SleepInIntervals() {
-      std::cout << "AC: Sleep in intervals" << std::endl;
       StopWatch timer;
       size_t numberOfSleeps = GetNumberOfSleepIntervals();
       while (KeepRunning() && numberOfSleeps > 0) {

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -6,6 +6,7 @@
 
 #include "AlarmClockTest.h"
 #include "AlarmClock.h"
+#include "MockAlarmClock.h"
 #include "StopWatch.h"
 #include <chrono>
 
@@ -234,5 +235,8 @@ TEST_F(AlarmClockTest, milliseconds_ResetBeforeExpired) {
    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
    std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-   
+}
+
+TEST_F(AlarmClockTest, MockAlarmClock) {
+   MockAlarmClock<seconds> alerter(1);
 }

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "AlarmClockTest.h"
-#include "AlarmClock.h"
 #include "MockAlarmClock.h"
 #include "StopWatch.h"
 #include <chrono>
@@ -22,7 +21,12 @@ namespace {
    typedef std::chrono::seconds seconds;
    
    template<typename T>
-   void WaitForAlarmClockToExpire(AlarmClock<T>& alerter) {
+   void WaitForBackgroundThreadToStart(MockAlarmClock<T>& alerter) {
+      while (!alerter.ThreadIsAlive());
+   }
+   
+   template<typename T>
+   void WaitForAlarmClockToExpire(MockAlarmClock<T>& alerter) {
       while (!alerter.Expired());
    }
 
@@ -58,185 +62,87 @@ namespace {
 
 TEST_F(AlarmClockTest, GetUsSleepTimeInUs) {
    int us = 123456;
-   AlarmClock<microseconds> alerter(us);
+   MockAlarmClock<microseconds> alerter(us);
    EXPECT_EQ(us, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, GetUsSleepTimeInMs) {
    int us = 123456;
-   AlarmClock<microseconds> alerter(us);
+   MockAlarmClock<microseconds> alerter(us);
    EXPECT_EQ(ConvertToMilliSeconds(microseconds(us)), alerter.SleepTimeMs());
 }
 
 TEST_F(AlarmClockTest, GetMsSleepTimeInMs) {
    int ms = 123456;
-   AlarmClock<milliseconds> alerter(ms);
+   MockAlarmClock<milliseconds> alerter(ms);
    EXPECT_EQ(ms, alerter.SleepTimeMs());
 }
 
 TEST_F(AlarmClockTest, GetMsSleepTimeInUs) {
    int ms = 123456;
-   AlarmClock<milliseconds> alerter(ms);
+   MockAlarmClock<milliseconds> alerter(ms);
    EXPECT_EQ(ConvertToMicroSeconds(milliseconds(ms)), alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, GetSecSleepTimeInUs) {
    int sec = 1;
-   AlarmClock<seconds> alerter(sec);
+   MockAlarmClock<seconds> alerter(sec);
    EXPECT_EQ(ConvertToMicroSeconds(seconds(sec)), alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, GetSecSleepTimeInMs) {
    int sec = 1;
-   AlarmClock<seconds> alerter(sec);
+   MockAlarmClock<seconds> alerter(sec);
    EXPECT_EQ(ConvertToMilliSeconds(seconds(sec)), alerter.SleepTimeMs());
-}
-
-TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
-   int us = 900;
-   StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us);
-   WaitForAlarmClockToExpire(alerter);
-   int totalTime = testTimer.ElapsedUs();
-   auto maxTime = us + GetTimingLeeway(microseconds(us));
-   EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
-   int us = 600000;
-   StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us);
-   WaitForAlarmClockToExpire(alerter);
-   int totalTime = testTimer.ElapsedUs();
-   auto maxTime = us + GetTimingLeeway(microseconds(us));
-   EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
-   int us = 724509;
-   StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us);
-   WaitForAlarmClockToExpire(alerter);
-   int totalTime = testTimer.ElapsedUs();
-   auto maxTime = us + GetTimingLeeway(microseconds(us));
-   EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, millisecondsLessThan500) {
-   unsigned int ms = 100;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
-   unsigned int ms = 1000;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
-   unsigned int ms = 1300;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, secondsSimple) {
-   int sec = 1;
-   StopWatch testTimer;
-   AlarmClock<seconds> alerter(sec);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto secToMicro = ConvertToMicroSeconds(seconds(sec));
-   EXPECT_TRUE(secToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << secToMicro;
-   auto maxTime = secToMicro + GetTimingLeeway(seconds(sec));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << secToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
 }
 
 TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {
    int sec = 60;
    StopWatch testTimer;
-   std::unique_ptr<AlarmClock<seconds>> acPtr(new AlarmClock<seconds>(sec));
-   std::this_thread::sleep_for(seconds(1));
+   std::unique_ptr<MockAlarmClock<seconds>> acPtr(new MockAlarmClock<seconds>(sec));
    EXPECT_EQ(ConvertToMilliSeconds(seconds(sec)), acPtr->SleepTimeMs());
    EXPECT_FALSE(acPtr->Expired());
    acPtr.reset();
-   EXPECT_TRUE(testTimer.ElapsedMs() < 10000);
+   EXPECT_TRUE(testTimer.ElapsedMs() < 1000);
 }
 
-TEST_F(AlarmClockTest, milliseconds_ResetAfterExpired) {
+TEST_F(AlarmClockTest, milliseconds_Reset) {
    // First run
    int ms = 750;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-   
-   // Reset after AlarmClock has expired
-   auto secondStartTime = testTimer.ElapsedUs();
+   MockAlarmClock<milliseconds> alerter(ms);
+   WaitForBackgroundThreadToStart(alerter);
+   EXPECT_EQ(1, alerter.GetNumberOfSleeps());
+
    alerter.Reset();
+   EXPECT_EQ(0, alerter.GetNumberOfSleeps());
+
    WaitForAlarmClockToExpire(alerter);
-   auto totalTime2 = testTimer.ElapsedUs() - secondStartTime;
-   EXPECT_TRUE(msToMicro <= totalTime2) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime2 << " sec, should be longer than " << msToMicro;
-   EXPECT_TRUE(totalTime2 <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime2 << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime2 << " us. Max timeout: " << maxTime << std::endl;
+   EXPECT_EQ(1, alerter.GetNumberOfSleeps());
 }
 
-TEST_F(AlarmClockTest, milliseconds_ResetBeforeExpired) {
-   // First run
-   int ms = 750;
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   std::this_thread::sleep_for(milliseconds(200));
-
-   // Reset the AlarmClock before it expires
-   alerter.Reset();
-   auto timeToReset = testTimer.ElapsedUs();
-   std::cout << "AlarmClock set for " << msToMicro << " us, only slept for " << timeToReset << " before being reset." <<  std::endl;
-   EXPECT_TRUE(timeToReset < msToMicro) << "AlarmClock slept for full amount of time although it was rest before it had expired.";
-
-   // Let second run expire
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs() - timeToReset;
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
-
-TEST_F(AlarmClockTest, MockAlarmClock) {
+TEST_F(AlarmClockTest, secondsSimple) {
+   int sec = 1;
    MockAlarmClock<seconds> alerter(1);
+   EXPECT_FALSE(alerter.Expired());
+   WaitForAlarmClockToExpire(alerter);
+   EXPECT_TRUE(alerter.Expired());
+   EXPECT_EQ(1, alerter.GetNumberOfSleeps());
+}
+
+TEST_F(AlarmClockTest, millisecondsSimple) {
+   int ms = 2200;
+   MockAlarmClock<milliseconds> alerter(ms);
+   EXPECT_FALSE(alerter.Expired());
+   WaitForAlarmClockToExpire(alerter);
+   EXPECT_TRUE(alerter.Expired());
+   EXPECT_EQ(4, alerter.GetNumberOfSleeps());
+}
+
+TEST_F(AlarmClockTest, microsecondsSimple) {
+   int us = 2200000;
+   MockAlarmClock<microseconds> alerter(us);
+   EXPECT_FALSE(alerter.Expired());
+   WaitForAlarmClockToExpire(alerter);
+   EXPECT_TRUE(alerter.Expired());
+   EXPECT_EQ(4, alerter.GetNumberOfSleeps());
 }


### PR DESCRIPTION
Added a MockAlarmClock class. It is not a true mocked class, but that implementation was not possible without changing the implementation of the base class to something less intuitive.

- Tests do not rely on sleeping for any amount of time
- Most functionality testing is done by ```EXPECT```-ing certain benchmarks in the code to hold certain values at certain points. For example, ```mockAlarmClock.Expired()``` should definitely be false before the background thread has spun up