### PR TITLE
Remove system time dependencies from tests

### DIFF
--- a/src/AlarmClock.h
+++ b/src/AlarmClock.h
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <thread>
 #include <atomic>
-#include <iostream>
 #include <future>
 #include <functional>
 #include "StopWatch.h"
@@ -26,7 +25,6 @@ public:
       kSleepTimeUsCount(ConvertToMicrosecondsCount(Duration(sleepDuration))),
       mSleepFunction(funcPtr) {
          if (mSleepFunction == nullptr) {
-            std::cout << "Sleep function is nullptr" << std::endl;
             mSleepFunction = std::bind(&AlarmClock::SleepUs, this, std::placeholders::_1);
          }
          mExited = std::async(std::launch::async, &AlarmClock::AlarmClockThread,this);
@@ -72,14 +70,11 @@ protected:
    }
 
    void SleepForFullAmount() {
-      std::cout << "Sleeping for full amount" << std::endl;
       mSleepFunction(kSleepTimeUsCount);
-      std::cout << "Done sleeping" << std::endl;
       mExpired.store(true);
    }
 
    void SleepUs(unsigned int t) {
-      std::cout << "We sleepin..." << std::endl;
       std::this_thread::sleep_for(microseconds(t));
    }
    
@@ -145,5 +140,3 @@ private:
    const unsigned int kSmallestIntervalInMS = 500;
    const unsigned int kSmallestIntervalInUS = 500 * 1000; // 500ms
 };
-
-

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -9,7 +9,7 @@
 #include "StopWatch.h"
 #include <chrono>
 
-unsigned int AlarmClockTest::kFakeSleepUs = 0;
+unsigned int AlarmClockTest::mFakeSleepUs = 0;
 
 namespace {
    typedef std::chrono::microseconds microseconds;
@@ -34,7 +34,7 @@ namespace {
    }
 
    void FakeSleep(unsigned int usToSleep) {
-      AlarmClockTest::kFakeSleepUs = usToSleep; 
+      AlarmClockTest::mFakeSleepUs = usToSleep; 
    }
 }
 
@@ -80,8 +80,8 @@ TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, us-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, us);
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, us-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, us);
 }
 
 TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
@@ -90,8 +90,8 @@ TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, us-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, us);
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, us-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, us);
 }
 
 TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
@@ -101,8 +101,8 @@ TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, us-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, us);
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, us-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, us);
 }
 
 TEST_F(AlarmClockTest, millisecondsLessThan500) {
@@ -111,8 +111,8 @@ TEST_F(AlarmClockTest, millisecondsLessThan500) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
@@ -121,8 +121,8 @@ TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
@@ -131,8 +131,8 @@ TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, secondsSimple) {
@@ -141,8 +141,8 @@ TEST_F(AlarmClockTest, secondsSimple) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
-   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
-   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
+   EXPECT_GE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::mFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -9,7 +9,7 @@
 #include "StopWatch.h"
 #include <chrono>
 
-unsigned int AlarmClockTest::mFakeSleepUs = 0;
+std::atomic<unsigned int> AlarmClockTest::mFakeSleepUs(0);
 
 namespace {
    typedef std::chrono::microseconds microseconds;
@@ -34,7 +34,7 @@ namespace {
    }
 
    void FakeSleep(unsigned int usToSleep) {
-      AlarmClockTest::mFakeSleepUs = usToSleep; 
+      AlarmClockTest::mFakeSleepUs.store(usToSleep); 
    }
 }
 

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -53,6 +53,10 @@ namespace {
          return kTimingLeeway * (timeInMicro / k500MsInMicro);
       }
    }
+
+   void FakeSleep() {
+      std::cout << "Fake Sleeping" << std::endl;
+   }
 }
 
 TEST_F(AlarmClockTest, GetUsSleepTimeInUs) {
@@ -94,7 +98,7 @@ TEST_F(AlarmClockTest, GetSecSleepTimeInMs) {
 TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
    int us = 900;
    StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us);
+   AlarmClock<microseconds> alerter(us, &FakeSleep);
    WaitForAlarmClockToExpire(alerter);
    int totalTime = testTimer.ElapsedUs();
    auto maxTime = us + GetTimingLeeway(microseconds(us));
@@ -103,136 +107,136 @@ TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
    std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
 }
 
-TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
-   int us = 600000;
-   StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us);
-   WaitForAlarmClockToExpire(alerter);
-   int totalTime = testTimer.ElapsedUs();
-   auto maxTime = us + GetTimingLeeway(microseconds(us));
-   EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
+// TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
+//    int us = 600000;
+//    StopWatch testTimer;
+//    AlarmClock<microseconds> alerter(us);
+//    WaitForAlarmClockToExpire(alerter);
+//    int totalTime = testTimer.ElapsedUs();
+//    auto maxTime = us + GetTimingLeeway(microseconds(us));
+//    EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
-   int us = 724509;
-   StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us);
-   WaitForAlarmClockToExpire(alerter);
-   int totalTime = testTimer.ElapsedUs();
-   auto maxTime = us + GetTimingLeeway(microseconds(us));
-   EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
+// TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
+//    int us = 724509;
+//    StopWatch testTimer;
+//    AlarmClock<microseconds> alerter(us);
+//    WaitForAlarmClockToExpire(alerter);
+//    int totalTime = testTimer.ElapsedUs();
+//    auto maxTime = us + GetTimingLeeway(microseconds(us));
+//    EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, millisecondsLessThan500) {
-   unsigned int ms = 100;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
+// TEST_F(AlarmClockTest, millisecondsLessThan500) {
+//    unsigned int ms = 100;
+//    StopWatch testTimer;
+//    AlarmClock<milliseconds> alerter(ms);
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime = testTimer.ElapsedUs();
+//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
+//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
-   unsigned int ms = 1000;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
+// TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
+//    unsigned int ms = 1000;
+//    StopWatch testTimer;
+//    AlarmClock<milliseconds> alerter(ms);
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime = testTimer.ElapsedUs();
+//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
+//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
-   unsigned int ms = 1300;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
+// TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
+//    unsigned int ms = 1300;
+//    StopWatch testTimer;
+//    AlarmClock<milliseconds> alerter(ms);
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime = testTimer.ElapsedUs();
+//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
+//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, secondsSimple) {
-   int sec = 1;
-   StopWatch testTimer;
-   AlarmClock<seconds> alerter(sec);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto secToMicro = ConvertToMicroSeconds(seconds(sec));
-   EXPECT_TRUE(secToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << secToMicro;
-   auto maxTime = secToMicro + GetTimingLeeway(seconds(sec));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << secToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-}
+// TEST_F(AlarmClockTest, secondsSimple) {
+//    int sec = 1;
+//    StopWatch testTimer;
+//    AlarmClock<seconds> alerter(sec);
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime = testTimer.ElapsedUs();
+//    auto secToMicro = ConvertToMicroSeconds(seconds(sec));
+//    EXPECT_TRUE(secToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << secToMicro;
+//    auto maxTime = secToMicro + GetTimingLeeway(seconds(sec));
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << secToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {
-   int sec = 60;
-   StopWatch testTimer;
-   std::unique_ptr<AlarmClock<seconds>> acPtr(new AlarmClock<seconds>(sec));
-   std::this_thread::sleep_for(seconds(1));
-   EXPECT_EQ(ConvertToMilliSeconds(seconds(sec)), acPtr->SleepTimeMs());
-   EXPECT_FALSE(acPtr->Expired());
-   acPtr.reset();
-   EXPECT_TRUE(testTimer.ElapsedMs() < 10000);
-}
+// TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {
+//    int sec = 60;
+//    StopWatch testTimer;
+//    std::unique_ptr<AlarmClock<seconds>> acPtr(new AlarmClock<seconds>(sec));
+//    std::this_thread::sleep_for(seconds(1));
+//    EXPECT_EQ(ConvertToMilliSeconds(seconds(sec)), acPtr->SleepTimeMs());
+//    EXPECT_FALSE(acPtr->Expired());
+//    acPtr.reset();
+//    EXPECT_TRUE(testTimer.ElapsedMs() < 10000);
+// }
 
-TEST_F(AlarmClockTest, milliseconds_ResetAfterExpired) {
-   // First run
-   int ms = 750;
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs();
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+// TEST_F(AlarmClockTest, milliseconds_ResetAfterExpired) {
+//    // First run
+//    int ms = 750;
+//    StopWatch testTimer;
+//    AlarmClock<milliseconds> alerter(ms);
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime = testTimer.ElapsedUs();
+//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
+//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
+//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
    
-   // Reset after AlarmClock has expired
-   auto secondStartTime = testTimer.ElapsedUs();
-   alerter.Reset();
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime2 = testTimer.ElapsedUs() - secondStartTime;
-   EXPECT_TRUE(msToMicro <= totalTime2) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime2 << " sec, should be longer than " << msToMicro;
-   EXPECT_TRUE(totalTime2 <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime2 << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime2 << " us. Max timeout: " << maxTime << std::endl;
-}
+//    // Reset after AlarmClock has expired
+//    auto secondStartTime = testTimer.ElapsedUs();
+//    alerter.Reset();
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime2 = testTimer.ElapsedUs() - secondStartTime;
+//    EXPECT_TRUE(msToMicro <= totalTime2) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime2 << " sec, should be longer than " << msToMicro;
+//    EXPECT_TRUE(totalTime2 <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime2 << " sec. Should be less than " << maxTime;
+//    std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime2 << " us. Max timeout: " << maxTime << std::endl;
+// }
 
-TEST_F(AlarmClockTest, milliseconds_ResetBeforeExpired) {
-   // First run
-   int ms = 750;
-   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-   StopWatch testTimer;
-   AlarmClock<milliseconds> alerter(ms);
-   std::this_thread::sleep_for(milliseconds(200));
+// TEST_F(AlarmClockTest, milliseconds_ResetBeforeExpired) {
+//    // First run
+//    int ms = 750;
+//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+//    StopWatch testTimer;
+//    AlarmClock<milliseconds> alerter(ms);
+//    std::this_thread::sleep_for(milliseconds(200));
 
-   // Reset the AlarmClock before it expires
-   alerter.Reset();
-   auto timeToReset = testTimer.ElapsedUs();
-   std::cout << "AlarmClock set for " << msToMicro << " us, only slept for " << timeToReset << " before being reset." <<  std::endl;
-   EXPECT_TRUE(timeToReset < msToMicro) << "AlarmClock slept for full amount of time although it was rest before it had expired.";
+//    // Reset the AlarmClock before it expires
+//    alerter.Reset();
+//    auto timeToReset = testTimer.ElapsedUs();
+//    std::cout << "AlarmClock set for " << msToMicro << " us, only slept for " << timeToReset << " before being reset." <<  std::endl;
+//    EXPECT_TRUE(timeToReset < msToMicro) << "AlarmClock slept for full amount of time although it was rest before it had expired.";
 
-   // Let second run expire
-   WaitForAlarmClockToExpire(alerter);
-   auto totalTime = testTimer.ElapsedUs() - timeToReset;
-   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
-   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-   std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+//    // Let second run expire
+//    WaitForAlarmClockToExpire(alerter);
+//    auto totalTime = testTimer.ElapsedUs() - timeToReset;
+//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
+//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
+//    std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
    
-}
+// }

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -54,9 +54,7 @@ namespace {
       }
    }
 
-   void FakeSleep() {
-      std::cout << "Fake Sleeping" << std::endl;
-   }
+   void FakeSleep(unsigned int ignored) {}
 }
 
 TEST_F(AlarmClockTest, GetUsSleepTimeInUs) {
@@ -97,8 +95,16 @@ TEST_F(AlarmClockTest, GetSecSleepTimeInMs) {
 
 TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
    int us = 900;
+   AlarmClock<microseconds> alerter(us, FakeSleep);
+   EXPECT_FALSE(alerter.Expired());
+   WaitForAlarmClockToExpire(alerter);
+   EXPECT_TRUE(alerter.Expired());
+}
+
+TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
+   int us = 600000;
    StopWatch testTimer;
-   AlarmClock<microseconds> alerter(us, &FakeSleep);
+   AlarmClock<microseconds> alerter(us);
    WaitForAlarmClockToExpire(alerter);
    int totalTime = testTimer.ElapsedUs();
    auto maxTime = us + GetTimingLeeway(microseconds(us));
@@ -107,136 +113,124 @@ TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
    std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
 }
 
-// TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
-//    int us = 600000;
-//    StopWatch testTimer;
-//    AlarmClock<microseconds> alerter(us);
-//    WaitForAlarmClockToExpire(alerter);
-//    int totalTime = testTimer.ElapsedUs();
-//    auto maxTime = us + GetTimingLeeway(microseconds(us));
-//    EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-// }
+TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
+   int us = 724509;
+   StopWatch testTimer;
+   AlarmClock<microseconds> alerter(us);
+   WaitForAlarmClockToExpire(alerter);
+   int totalTime = testTimer.ElapsedUs();
+   auto maxTime = us + GetTimingLeeway(microseconds(us));
+   EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+   std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+}
 
-// TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
-//    int us = 724509;
-//    StopWatch testTimer;
-//    AlarmClock<microseconds> alerter(us);
-//    WaitForAlarmClockToExpire(alerter);
-//    int totalTime = testTimer.ElapsedUs();
-//    auto maxTime = us + GetTimingLeeway(microseconds(us));
-//    EXPECT_TRUE(us <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << us;
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << us << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-// }
+TEST_F(AlarmClockTest, millisecondsLessThan500) {
+   unsigned int ms = 100;
+   StopWatch testTimer;
+   AlarmClock<milliseconds> alerter(ms);
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime = testTimer.ElapsedUs();
+   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
+   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+}
 
-// TEST_F(AlarmClockTest, millisecondsLessThan500) {
-//    unsigned int ms = 100;
-//    StopWatch testTimer;
-//    AlarmClock<milliseconds> alerter(ms);
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime = testTimer.ElapsedUs();
-//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-// }
+TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
+   unsigned int ms = 1000;
+   StopWatch testTimer;
+   AlarmClock<milliseconds> alerter(ms);
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime = testTimer.ElapsedUs();
+   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
+   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+}
 
-// TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
-//    unsigned int ms = 1000;
-//    StopWatch testTimer;
-//    AlarmClock<milliseconds> alerter(ms);
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime = testTimer.ElapsedUs();
-//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-// }
+TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
+   unsigned int ms = 1300;
+   StopWatch testTimer;
+   AlarmClock<milliseconds> alerter(ms);
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime = testTimer.ElapsedUs();
+   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
+   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
+   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+}
 
-// TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
-//    unsigned int ms = 1300;
-//    StopWatch testTimer;
-//    AlarmClock<milliseconds> alerter(ms);
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime = testTimer.ElapsedUs();
-//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " us, should be longer than " << msToMicro;
-//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " us. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-// }
+TEST_F(AlarmClockTest, secondsSimple) {
+   int sec = 1;
+   StopWatch testTimer;
+   AlarmClock<seconds> alerter(sec);
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime = testTimer.ElapsedUs();
+   auto secToMicro = ConvertToMicroSeconds(seconds(sec));
+   EXPECT_TRUE(secToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << secToMicro;
+   auto maxTime = secToMicro + GetTimingLeeway(seconds(sec));
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
+   std::cout << "Timeout was set for " << secToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+}
 
-// TEST_F(AlarmClockTest, secondsSimple) {
-//    int sec = 1;
-//    StopWatch testTimer;
-//    AlarmClock<seconds> alerter(sec);
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime = testTimer.ElapsedUs();
-//    auto secToMicro = ConvertToMicroSeconds(seconds(sec));
-//    EXPECT_TRUE(secToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << secToMicro;
-//    auto maxTime = secToMicro + GetTimingLeeway(seconds(sec));
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << secToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
-// }
+TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {
+   int sec = 60;
+   StopWatch testTimer;
+   std::unique_ptr<AlarmClock<seconds>> acPtr(new AlarmClock<seconds>(sec));
+   std::this_thread::sleep_for(seconds(1));
+   EXPECT_EQ(ConvertToMilliSeconds(seconds(sec)), acPtr->SleepTimeMs());
+   EXPECT_FALSE(acPtr->Expired());
+   acPtr.reset();
+   EXPECT_TRUE(testTimer.ElapsedMs() < 10000);
+}
 
-// TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {
-//    int sec = 60;
-//    StopWatch testTimer;
-//    std::unique_ptr<AlarmClock<seconds>> acPtr(new AlarmClock<seconds>(sec));
-//    std::this_thread::sleep_for(seconds(1));
-//    EXPECT_EQ(ConvertToMilliSeconds(seconds(sec)), acPtr->SleepTimeMs());
-//    EXPECT_FALSE(acPtr->Expired());
-//    acPtr.reset();
-//    EXPECT_TRUE(testTimer.ElapsedMs() < 10000);
-// }
-
-// TEST_F(AlarmClockTest, milliseconds_ResetAfterExpired) {
-//    // First run
-//    int ms = 750;
-//    StopWatch testTimer;
-//    AlarmClock<milliseconds> alerter(ms);
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime = testTimer.ElapsedUs();
-//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
-//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-//    std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+TEST_F(AlarmClockTest, milliseconds_ResetAfterExpired) {
+   // First run
+   int ms = 750;
+   StopWatch testTimer;
+   AlarmClock<milliseconds> alerter(ms);
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime = testTimer.ElapsedUs();
+   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
+   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
+   std::cout << "Timeout was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
    
-//    // Reset after AlarmClock has expired
-//    auto secondStartTime = testTimer.ElapsedUs();
-//    alerter.Reset();
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime2 = testTimer.ElapsedUs() - secondStartTime;
-//    EXPECT_TRUE(msToMicro <= totalTime2) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime2 << " sec, should be longer than " << msToMicro;
-//    EXPECT_TRUE(totalTime2 <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime2 << " sec. Should be less than " << maxTime;
-//    std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime2 << " us. Max timeout: " << maxTime << std::endl;
-// }
+   // Reset after AlarmClock has expired
+   auto secondStartTime = testTimer.ElapsedUs();
+   alerter.Reset();
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime2 = testTimer.ElapsedUs() - secondStartTime;
+   EXPECT_TRUE(msToMicro <= totalTime2) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime2 << " sec, should be longer than " << msToMicro;
+   EXPECT_TRUE(totalTime2 <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime2 << " sec. Should be less than " << maxTime;
+   std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime2 << " us. Max timeout: " << maxTime << std::endl;
+}
 
-// TEST_F(AlarmClockTest, milliseconds_ResetBeforeExpired) {
-//    // First run
-//    int ms = 750;
-//    auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
-//    StopWatch testTimer;
-//    AlarmClock<milliseconds> alerter(ms);
-//    std::this_thread::sleep_for(milliseconds(200));
+TEST_F(AlarmClockTest, milliseconds_ResetBeforeExpired) {
+   // First run
+   int ms = 750;
+   auto msToMicro = ConvertToMicroSeconds(milliseconds(ms));
+   StopWatch testTimer;
+   AlarmClock<milliseconds> alerter(ms);
+   std::this_thread::sleep_for(milliseconds(200));
 
-//    // Reset the AlarmClock before it expires
-//    alerter.Reset();
-//    auto timeToReset = testTimer.ElapsedUs();
-//    std::cout << "AlarmClock set for " << msToMicro << " us, only slept for " << timeToReset << " before being reset." <<  std::endl;
-//    EXPECT_TRUE(timeToReset < msToMicro) << "AlarmClock slept for full amount of time although it was rest before it had expired.";
+   // Reset the AlarmClock before it expires
+   alerter.Reset();
+   auto timeToReset = testTimer.ElapsedUs();
+   std::cout << "AlarmClock set for " << msToMicro << " us, only slept for " << timeToReset << " before being reset." <<  std::endl;
+   EXPECT_TRUE(timeToReset < msToMicro) << "AlarmClock slept for full amount of time although it was rest before it had expired.";
 
-//    // Let second run expire
-//    WaitForAlarmClockToExpire(alerter);
-//    auto totalTime = testTimer.ElapsedUs() - timeToReset;
-//    EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
-//    auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
-//    EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
-//    std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
+   // Let second run expire
+   WaitForAlarmClockToExpire(alerter);
+   auto totalTime = testTimer.ElapsedUs() - timeToReset;
+   EXPECT_TRUE(msToMicro <= totalTime) << "AlarmClock didn't sleep for long enough. Slept for: " << totalTime << " sec, should be longer than " << msToMicro;
+   auto maxTime = msToMicro + GetTimingLeeway(milliseconds(ms));
+   EXPECT_TRUE(totalTime <= maxTime) << "AlarmClock took too long to expire. Took " << totalTime << " sec. Should be less than " << maxTime;
+   std::cout << "Timeout (after reset) was set for " << msToMicro << " us. Actually slept for " << totalTime << " us. Max timeout: " << maxTime << std::endl;
    
-// }
+}

--- a/test/AlarmClockTest.cpp
+++ b/test/AlarmClockTest.cpp
@@ -9,11 +9,15 @@
 #include "StopWatch.h"
 #include <chrono>
 
+unsigned int AlarmClockTest::kFakeSleepUs = 0;
+
 namespace {
    typedef std::chrono::microseconds microseconds;
    typedef std::chrono::milliseconds milliseconds;
    typedef std::chrono::seconds seconds;
-   
+
+   unsigned int kFakeSleepLeeway = 100;
+
    template<typename T>
    void WaitForAlarmClockToExpire(AlarmClock<T>& alerter) {
       while (!alerter.Expired());
@@ -29,7 +33,9 @@ namespace {
       return std::chrono::duration_cast<milliseconds>(t).count();
    }
 
-   void FakeSleep(unsigned int ignored) {}
+   void FakeSleep(unsigned int usToSleep) {
+      AlarmClockTest::kFakeSleepUs = usToSleep; 
+   }
 }
 
 TEST_F(AlarmClockTest, GetUsSleepTimeInUs) {
@@ -74,6 +80,8 @@ TEST_F(AlarmClockTest, microsecondsLessThan500ms) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, us-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, us);
 }
 
 TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
@@ -82,14 +90,19 @@ TEST_F(AlarmClockTest, microsecondsGreaterThan500ms) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, us-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, us);
 }
 
 TEST_F(AlarmClockTest, weirdNumberOfMicroseconds) {
    int us = 724509;
+   StopWatch sw;
    AlarmClock<microseconds> alerter(us, FakeSleep);
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, us-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, us);
 }
 
 TEST_F(AlarmClockTest, millisecondsLessThan500) {
@@ -98,6 +111,8 @@ TEST_F(AlarmClockTest, millisecondsLessThan500) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
@@ -106,6 +121,8 @@ TEST_F(AlarmClockTest, oneSecondInMilliseconds) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
@@ -114,6 +131,8 @@ TEST_F(AlarmClockTest, millisecondsNotDivisibleBy500) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, secondsSimple) {
@@ -122,6 +141,8 @@ TEST_F(AlarmClockTest, secondsSimple) {
    EXPECT_FALSE(alerter.Expired());
    WaitForAlarmClockToExpire(alerter);
    EXPECT_TRUE(alerter.Expired());
+   EXPECT_GE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs()-kFakeSleepLeeway);
+   EXPECT_LE(AlarmClockTest::kFakeSleepUs, alerter.SleepTimeUs());
 }
 
 TEST_F(AlarmClockTest, LongTimeout_ImmediatelyDestructed) {

--- a/test/AlarmClockTest.h
+++ b/test/AlarmClockTest.h
@@ -13,11 +13,11 @@ public:
 
    AlarmClockTest() {};
 
-   static unsigned int kFakeSleepUs;
+   static unsigned int mFakeSleepUs;
 
 protected:
 
-   virtual void SetUp() { AlarmClockTest::kFakeSleepUs = 0; };
+   virtual void SetUp() { AlarmClockTest::mFakeSleepUs = 0; };
 
-   virtual void TearDown() { AlarmClockTest::kFakeSleepUs = 0; };
+   virtual void TearDown() { AlarmClockTest::mFakeSleepUs = 0; };
 };

--- a/test/AlarmClockTest.h
+++ b/test/AlarmClockTest.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+#include "AlarmClock.h"
 #include "gtest/gtest.h"
 
 class AlarmClockTest : public ::testing::Test {
@@ -12,9 +13,11 @@ public:
 
    AlarmClockTest() {};
 
+   static unsigned int kFakeSleepUs;
+
 protected:
 
-   virtual void SetUp() {};
+   virtual void SetUp() { AlarmClockTest::kFakeSleepUs = 0; };
 
-   virtual void TearDown() {};
+   virtual void TearDown() { AlarmClockTest::kFakeSleepUs = 0; };
 };

--- a/test/AlarmClockTest.h
+++ b/test/AlarmClockTest.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "AlarmClock.h"
+#include <atomic>
 #include "gtest/gtest.h"
 
 class AlarmClockTest : public ::testing::Test {
@@ -13,7 +14,7 @@ public:
 
    AlarmClockTest() {};
 
-   static unsigned int mFakeSleepUs;
+   static std::atomic<unsigned int> mFakeSleepUs;
 
 protected:
 


### PR DESCRIPTION
- AlarmClock constructor optionally takes a function pointer. This can be used to override the ```Sleep()``` function in the tests so that they don't actually call ```std::this_thread::sleep_for()```

- Tests updated with new constructor usage

- Existing syntax works properly, nothing in Research should break
